### PR TITLE
SPF fix

### DIFF
--- a/dnsknife/__init__.py
+++ b/dnsknife/__init__.py
@@ -231,9 +231,11 @@ class Checker(TypeAware):
 
     def txt_spf(self):
         """Return first TXT/spf record for domain"""
-        for rec in self.txt():
-            if rec.startswith('v=spf'):
-                return rec
+        txt = self.txt()
+        if txt:
+            for rec in txt.split("\n"):        
+                if rec.startswith('v=spf'):
+                    return rec
 
     def spf(self):
         try:


### PR DESCRIPTION
SPF command should return TXT-SPF RR if SPF RR is not set. There is a bug in the code that handles TXT response as a list whereas it is a mere string.